### PR TITLE
Firefox 3.6 browser version

### DIFF
--- a/lib/celerity/browser.rb
+++ b/lib/celerity/browser.rb
@@ -829,13 +829,13 @@ module Celerity
                         when :firefox, :ff, :firefox3, :ff3 # default :firefox
                           ::HtmlUnit::BrowserVersion::FIREFOX_3
                         when :firefox_3_6, :ff36
-                          ::HtmlUnit::BrowserVersion::FIREFOX_3
+                          ::HtmlUnit::BrowserVersion::FIREFOX_3_6
                         when :internet_explorer_6, :ie6
                           ::HtmlUnit::BrowserVersion::INTERNET_EXPLORER_6
-                        when :internet_explorer, :ie, :internet_explorer7, :ie7  # default :ie
+                        when :internet_explorer, :ie, :internet_explorer7, :internet_explorer_7, :ie7  # default :ie
                           ::HtmlUnit::BrowserVersion::INTERNET_EXPLORER_7
                         when :internet_explorer_8, :ie8
-                          ::HtmlUnit::BrowserVersion::INTERNET_EXPLORER_7
+                          ::HtmlUnit::BrowserVersion::INTERNET_EXPLORER_8
                         else
                           raise ArgumentError, "unknown browser: #{browser.inspect}"
                         end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -88,6 +88,29 @@ describe "Browser" do
         b.close
       end
     end
+    
+    it "should use the Firefox 3 browser version when specified" do
+      Browser.new(:browser => :firefox).webclient.browser_version.nickname.should == "FF3"
+      Browser.new(:browser => :firefox3).webclient.browser_version.nickname.should == "FF3"
+    end
+    
+    it "should use the Firefox 3.6 browser version when specified" do
+      Browser.new(:browser => :firefox_3_6).webclient.browser_version.nickname.should == "FF3.6"
+      Browser.new(:browser => :ff36).webclient.browser_version.nickname.should == "FF3.6"
+    end
+
+    it "should use the Internet Explorer 7 browser version when specified" do
+      Browser.new(:browser => :internet_explorer).webclient.browser_version.nickname.should == "IE7"
+      Browser.new(:browser => :internet_explorer7).webclient.browser_version.nickname.should == "IE7"
+      Browser.new(:browser => :internet_explorer_7).webclient.browser_version.nickname.should == "IE7"
+      Browser.new(:browser => :ie).webclient.browser_version.nickname.should == "IE7"
+    end
+    
+    it "should use the Internet Explorer 8 browser version when specified" do
+      Browser.new(:browser => :internet_explorer_8).webclient.browser_version.nickname.should == "IE8"
+      Browser.new(:browser => :ie8).webclient.browser_version.nickname.should == "IE8"
+    end
+    
   end
 
   describe "#html" do
@@ -369,5 +392,7 @@ describe "Browser" do
       end
     end
   end
+  
+
 
 end


### PR DESCRIPTION
I'm testing a web app that uses localStorage. HtmlUnit supports localStorage, but it requires Firefox 3.6.

It looks like you had put some preliminary support in for the new browser versions available in HtmlUnit, but were not actually using the newer versions. I'm not sure if this was intentional or not. 

I updated the code to correctly use the newer versions and added some specs. 

Thanks,
Patrick
