### PR TITLE
Include xpath in exception message for element_by_xpath

### DIFF
--- a/lib/celerity/element.rb
+++ b/lib/celerity/element.rb
@@ -9,7 +9,8 @@ module Celerity
     include Container
 
     attr_reader :container
-
+    attr_writer :locator_identifier
+    
     # HTML 4.01 Transitional DTD
     HTML_401_TRANSITIONAL = {
       :core        => [:class, :id, :style, :title],
@@ -290,7 +291,9 @@ module Celerity
     private
 
     def identifier_string
-      if @conditions.size == 1
+      if @locator_identifier
+        @locator_identifier
+      elsif @conditions.size == 1
         how, what = @conditions.to_a.first
         "#{how.inspect} and #{what.inspect}"
       else

--- a/lib/celerity/xpath_support.rb
+++ b/lib/celerity/xpath_support.rb
@@ -16,7 +16,7 @@ module Celerity
     def element_by_xpath(xpath)
       assert_exists
       obj = @page.getFirstByXPath(xpath)
-      element_from_dom_node(obj)
+      element_from_dom_node(obj, "#{self.class.name}#element_by_xpath and #{xpath.inspect}")
     end
 
     #
@@ -30,16 +30,17 @@ module Celerity
       assert_exists
       objects = @page.getByXPath(xpath)
       # should use an ElementCollection here?
-      objects.map { |o| element_from_dom_node(o) }.compact
+      objects.map { |o| element_from_dom_node(o, "#{self.class.name}#elements_by_xpath and #{xpath.inspect}") }.compact
     end
 
     #
     # Convert the given HtmlUnit DomNode to a Celerity object
     #
 
-    def element_from_dom_node(obj)
+    def element_from_dom_node(obj, locator_identifier = nil)
       element_class = Util.htmlunit2celerity(obj.class) || Element
       element = element_class.new(self, :object, obj)
+      element.locator_identifier = locator_identifier
 
       element.extend(ClickableElement) unless element.is_a?(ClickableElement)
 

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -294,8 +294,21 @@ describe "Browser" do
       el.should be_kind_of(Celerity::ClickableElement)
       el.rel.should == "stylesheet"
     end
-  end
+    
+    it "includes the xpath in an exception message" do
+      browser.goto(WatirSpec.files + "/forms_with_input_elements.html")
 
+      the_xpath = "//div[contains(@class, 'this does not exist')]"
+      el = browser.element_by_xpath(the_xpath)
+      begin
+        el.visible?
+        raise "visible? should have raised an error"
+      rescue Celerity::Exception::UnknownObjectException => ex
+        ex.message.should include(the_xpath)
+      end
+    end
+  end
+  
   describe "#focused_element" do
     it "returns the element that currently has the focus" do
       b = WatirSpec.new_browser

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -15,6 +15,13 @@ describe "Element" do
       elem.public_identifier_string
       elem.id.should == 'hidden_parent'
     end
+    
+    it "uses the user specified locator_identifier if one is present" do
+      elem = browser.div(:id, 'hidden_parent')
+      elem.locator_identifier = "this is it"
+      def elem.public_identifier_string; identifier_string end # method is private
+      elem.public_identifier_string.should == "this is it"
+    end
   end
 
   describe "#method_missing" do


### PR DESCRIPTION
This patch improves the error message one gets when an element returned by #element_by_xpath does not exist. Previously you would get an exception with a message like this:

> Unable to locate Element, using :object and nil

The new message would be something like:

> Unable to locate Element, using Celerity::Browser#element_by_xpath and "//div[contains(@class, 'foo')]"
