### PR TITLE
Default celerity to set accept header to "text/html" rather than "*/*" and add override mechanism.

### DIFF
--- a/lib/celerity/browser.rb
+++ b/lib/celerity/browser.rb
@@ -90,10 +90,12 @@ module Celerity
     # @return [String] The url.
     #
 
-    def goto(uri)
+    def goto(uri, headers={})
       uri = "http://#{uri}" unless uri =~ %r{://}
 
+      headers['Accept'] ||= 'text/html'
       request = HtmlUnit::WebRequestSettings.new(::Java::JavaNet::URL.new(uri))
+      request.set_additional_headers(headers)
       request.setCharset(@charset)
 
       rescue_status_code_exception do

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -175,6 +175,17 @@ describe "Browser" do
     it "raises UnexpectedPageException if the content type is not understood" do
       lambda { browser.goto(WatirSpec.host + "/octet_stream") }.should raise_error(UnexpectedPageException)
     end
+
+    it "takes a 2nd argument of headers", :only_this => true do
+      browser.goto(WatirSpec.host + "/header_echo", {'Accept-Language'=>'fr','Accept'=>'application/json'})
+      browser.text.should include('"HTTP_ACCEPT"=>"application/json"')
+      browser.text.should include('"HTTP_ACCEPT_LANGUAGE"=>"fr"')
+    end
+
+    it "the header arguments defaults to 'text/html' if not set", :only_this => true do
+      browser.goto(WatirSpec.host + "/header_echo")
+      browser.text.should include('"HTTP_ACCEPT"=>"text/html"')
+    end
   end
 
   describe "#cookies" do


### PR DESCRIPTION
HTMLUnit sends the first request to a server with accept header set to "_/_". This causes some servers to not respond with HTML and is probably not what's intended. For a more detailed discussion, see here: http://stackoverflow.com/questions/4824028/celerity-cannot-follow-a-devise-redirect-because-celerity-doesnt-send-an-accept

I've added the ability to set the accept header explicitly in the Browser#goto method. If it's not set, it'll default to "text/html" rather than "_/_".  This change was TDD's and tests are included.
