### PR TITLE
1.9 compatibility fix

### DIFF
--- a/lib/celerity/browser.rb
+++ b/lib/celerity/browser.rb
@@ -81,7 +81,12 @@ module Celerity
     end
 
     def inspect
-      short_inspect :exclude => %w[@webclient @browser @object @options @listener @event_listener]
+      exclude = %w[@webclient @browser @object @options @listener @event_listener]
+      if RUBY_VERSION.split(".")[0] != "8"
+        # in 1.9 mode (and probably beyond), ivars are Symbols, not Strings
+        exclude.map! { |v| v.to_sym }
+      end
+      short_inspect :exclude => exclude
     end
 
     #

--- a/lib/celerity/container.rb
+++ b/lib/celerity/container.rb
@@ -61,7 +61,11 @@ module Celerity
     #
 
     def inspect
-      short_inspect :include => %w[@conditions @object]
+      exclude = %w[@conditions @object]
+      if RUBY_VERSION.split(".")[0] == "8"
+        exclude.map! { |v| v.to_sym }
+      end
+      short_inspect :include => exclude
     end
 
     #


### PR DESCRIPTION
In 1.9 mode, ivars are Symbols, not Strings. As `Celerity::Browser` contains a reference to another instance of `Celerity::Browser`, `Celerity::Browser#inspect` falls into an infinite loop of sorts, and quickly blows the JVM stack.

This fixes http://bugs.jruby.org/6273.
